### PR TITLE
fix strncpy string truncation warning/error

### DIFF
--- a/src/lib/tapcfg_unix_linux.h
+++ b/src/lib/tapcfg_unix_linux.h
@@ -61,7 +61,7 @@ tapcfg_start_dev(tapcfg_t *tapcfg, const char *ifname, int fallback)
 
 	/* Set the device name to be the one we got from OS */
 	taplog_log(&tapcfg->taplog, TAPLOG_DEBUG, "Device name %s", ifr.ifr_name);
-	strncpy(tapcfg->ifname, ifr.ifr_name, sizeof(tapcfg->ifname)-1);
+	strncpy(tapcfg->ifname, ifr.ifr_name, sizeof(tapcfg->ifname));
 
 	/* Create a temporary socket for SIOCGIFHWADDR */
 	s = socket(AF_INET, SOCK_DGRAM, 0);


### PR DESCRIPTION
Eliminate the following error:

  In file included from tapcfg/src/lib/tapcfg_unix.c:60,
                   from tapcfg/src/lib/tapcfg.c:31:
  In function ‘tapcfg_start_dev’,
      inlined from ‘tapcfg_start’ at tapcfg/src/lib/tapcfg_unix.c:112:11:
  tapcfg/src/lib/tapcfg_unix_linux.h:64:2: error: ‘strncpy’ output may be
      truncated copying 15 bytes from a string of length 15
      [-Werror=stringop-truncation]
  strncpy(tapcfg->ifname, ifr.ifr_name, sizeof(tapcfg->ifname)-1);
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~